### PR TITLE
Input requirements for Evaluation, EmpiricalCalibrationUsingMcmc and ConfidenceIntervalCalibration

### DIFF
--- a/tests/testthat/test-confidenceIntervalCalibration.R
+++ b/tests/testthat/test-confidenceIntervalCalibration.R
@@ -1,0 +1,66 @@
+library(testthat)
+library(EmpiricalCalibration)
+
+data(sccs)
+negatives <- sccs[sccs$groundTruth == 0, ]
+
+test_that("fitSystematicErrorModel requirements", {
+  logRr     <- c(0, 0)
+  seLogRr   <- c(1, Inf)
+  trueLogRr <- c(0, 0)
+  
+  # Infinite standard error
+  expect_warning(
+    fitSystematicErrorModel(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*infinite standard error"
+  )
+  
+  # Infinite logRr
+  logRr   <- c(0, Inf)
+  seLogRr <- c(1, 0)
+  expect_warning(
+    fitSystematicErrorModel(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*infinite logRr"
+  )
+  
+  # seLogRr is NA
+  logRr   <- c(0, 0)
+  seLogRr <- c(1, NA)
+  expect_warning(
+    fitSystematicErrorModel(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*NA standard error.*"
+  )
+  
+  # logRr is NA
+  logRr   <- c(0, NA)
+  seLogRr <- c(1, 0)
+  expect_warning(
+    fitSystematicErrorModel(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*NA logRr.*"
+  )
+})
+
+test_that("convertNullToErrorModel requirements", {
+  null <- 0
+  class(null) <- "mcmcNul"
+  expect_error(
+    convertNullToErrorModel(null = null),
+    regexp = ".*type 'null'.*"
+  )
+})

--- a/tests/testthat/test-empiricalCalibrationUsingMcmc.R
+++ b/tests/testthat/test-empiricalCalibrationUsingMcmc.R
@@ -2,7 +2,7 @@ library(testthat)
 library(EmpiricalCalibration)
 
 data(sccs)
-negatives <- sccs[sccs$groundTruth == 0, ]
+# negatives <- sccs[sccs$groundTruth == 0, ]
 
 test_that("fitMcmcNull requirements", {
   

--- a/tests/testthat/test-empiricalCalibrationUsingMcmc.R
+++ b/tests/testthat/test-empiricalCalibrationUsingMcmc.R
@@ -1,0 +1,53 @@
+library(testthat)
+library(EmpiricalCalibration)
+
+data(sccs)
+negatives <- sccs[sccs$groundTruth == 0, ]
+
+test_that("fitMcmcNull requirements", {
+  
+  # Infinite logRr
+  logRr     <- c(0, Inf)
+  seLogRr   <- c(1, 0)
+  expect_warning(
+    fitMcmcNull(
+      logRr     = logRr,
+      seLogRr   = seLogRr
+    ),
+    regexp = ".*infinite logRr.*"
+  )
+  
+  # Infinite seLogRr
+  logRr     <- c(0, 0)
+  seLogRr   <- c(1, Inf)
+  expect_warning(
+    fitMcmcNull(
+      logRr     = logRr,
+      seLogRr   = seLogRr
+    ),
+    regexp = ".*infinite standard error.*"
+  )
+  
+  # NA logRr
+  logRr     <- c(0, NA)
+  seLogRr   <- c(1, 0)
+  expect_warning(
+    fitMcmcNull(
+      logRr     = logRr,
+      seLogRr   = seLogRr
+    ),
+    regexp = ".*NA logRr.*"
+  )
+  
+  # NA seLogRr
+  logRr     <- c(0, 0)
+  seLogRr   <- c(1, NA)
+  expect_warning(
+    fitMcmcNull(
+      logRr     = logRr,
+      seLogRr   = seLogRr
+    ),
+    regexp = ".*NA standard error.*"
+  )
+})
+  

--- a/tests/testthat/test-evaluation.R
+++ b/tests/testthat/test-evaluation.R
@@ -18,7 +18,7 @@ test_that("evaluateCiCalibration requirements", {
       trueLogRr = trueLogRr,
       strata    = strata
     ),
-    regexp = ".*factor or (null).*"
+    regexp = "factor"
   )
   
   # Infinite logRr

--- a/tests/testthat/test-evaluation.R
+++ b/tests/testthat/test-evaluation.R
@@ -1,0 +1,75 @@
+library(testthat)
+library(EmpiricalCalibration)
+
+data(sccs)
+negatives <- sccs[sccs$groundTruth == 0, ]
+negatives <- negatives[1:5, ]
+
+test_that("evaluateCiCalibration requirements", {
+  
+  logRr     <- c(0, 0)
+  seLogRr   <- c(1, 0)
+  trueLogRr <- c(0, 0)
+  strata    <- c("strat1", "strat2")
+  expect_error(
+    evaluateCiCalibration(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr,
+      strata    = strata
+    ),
+    regexp = ".*factor or (null).*"
+  )
+  
+  # Infinite logRr
+  logRr     <- c(negatives$logRr, Inf)
+  seLogRr   <- c(negatives$seLogRr, 0)
+  trueLogRr <- c(negatives$groundTruth, 0)
+  expect_warning(
+    evaluateCiCalibration(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*infinite logRr.*"
+  )
+  
+  # Infinite seLogRr
+  logRr     <- c(negatives$logRr, 0)
+  seLogRr   <- c(negatives$seLogRr, Inf)
+  trueLogRr <- c(negatives$groundTruth, 0)
+  expect_warning(
+    evaluateCiCalibration(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*infinite standard error.*"
+  )
+  
+  # logRr is NA
+  logRr     <- c(negatives$logRr, NA)
+  seLogRr   <- c(negatives$seLogRr, 0)
+  trueLogRr <- c(negatives$groundTruth, 0)
+  expect_warning(
+    evaluateCiCalibration(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*NA logRr.*"
+  )
+  
+  # seLogRr is NA
+  logRr     <- c(negatives$logRr, 0)
+  seLogRr   <- c(negatives$seLogRr, NA)
+  trueLogRr <- c(negatives$groundTruth, 0)
+  expect_warning(
+    evaluateCiCalibration(
+      logRr     = logRr,
+      seLogRr   = seLogRr,
+      trueLogRr = trueLogRr
+    ),
+    regexp = ".*NA standard error.*"
+  )
+})


### PR DESCRIPTION
Basic tests checking desired behavior of inappropriate input for `Evaluation.R`, `EmpiricalCalibrationUsingMcmc.R` and `ConfidenceIntervalCalibration.R`